### PR TITLE
Fix invalid buffer length return

### DIFF
--- a/proxy/apiserver/router/serializer.go
+++ b/proxy/apiserver/router/serializer.go
@@ -198,12 +198,16 @@ func (s *responseSerializer) EncodeList(obj runtime.Object) (io.ReadCloser, int,
 	if s.gzipWriter != nil {
 		s.gzipWriter.Reset(s.buf)
 		w = s.gzipWriter
-		defer s.gzipWriter.Close()
 	}
 
 	if err := s.encoder.Encode(obj, w); err != nil {
 		return nil, 0, err
 	}
+
+	if s.gzipWriter != nil {
+		s.gzipWriter.Close()
+	}
+
 	return &serializerReaderCloser{Reader: s.buf, serializer: s}, s.buf.Len(), nil
 }
 


### PR DESCRIPTION
```
func (s *responseSerializer) EncodeList(obj runtime.Object) (io.ReadCloser, int, error) {
	s.resetBuf()
	var w io.Writer = s.buf
	if s.gzipWriter != nil {
		s.gzipWriter.Reset(s.buf)
		w = s.gzipWriter
		defer s.gzipWriter.Close()
	}

	if err := s.encoder.Encode(obj, w); err != nil {
		return nil, 0, err
	}
	return &serializerReaderCloser{Reader: s.buf, serializer: s}, s.buf.Len(), nil
}
```

**Bug report**
`return s.buf.Len()` is assigned before `defer s.gzipWriter.Close()` 