### PR TITLE
Fix invalide slice append in readStreaming func

### DIFF
--- a/proxy/apiserver/router/serializer.go
+++ b/proxy/apiserver/router/serializer.go
@@ -209,7 +209,7 @@ func (s *responseSerializer) EncodeList(obj runtime.Object) (io.ReadCloser, int,
 
 func (s *responseSerializer) DecodeWatch() (*metav1.WatchEvent, runtime.Object, error) {
 	s.resetBuf()
-	n, err := s.reader.readStreaming(s.buf.Bytes()[:s.buf.Cap()])
+	n, err := s.reader.readStreaming(s.buf)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
**Bug fix**
Invalid expansion：append buffer slice in func with no return. (A new address is allocated and needs to be assigned)
Insufficient `buf[] `capacity will cause out-of-bounds. （`n` has become larger, but `buf[] `cap in buffer has not changed）
`buf = append(buf, make([]byte, len(buf))...)`
